### PR TITLE
Fix: Rename PORT to API_PORT in .env.example for consistency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,5 @@ BATCH_SIZE=100    # Default: 100
 POLLING_INTERVAL_MS=1000  # Default: 1000
 
 # API configuration
-PORT=3000  # Default: 3000
+API_PORT=3000  # Default: 3000
 API_HOST=0.0.0.0  # Default: 0.0.0.0


### PR DESCRIPTION
# Fix environment variable name in .env.example

## Issue
The .env.example file currently uses `PORT` as the variable name for the API port configuration, but the application code references this setting as `API_PORT`. This inconsistency can cause confusion during setup.

## Changes
- Renamed `PORT` to `API_PORT` in .env.example to match the actual variable name used in the codebase

## Why
This change improves developer experience by ensuring the example environment configuration accurately reflects the variable names expected by the application.