### PR TITLE
Update API service configuration for consistent env vars and port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,12 +15,13 @@ services:
   api:
     build: .
     ports:
-      - "${po}:${API_PORT}"
+      - "${PORT}:${PORT}"
     depends_on:
       - db
     environment:
+      - SOURCE_DB_URL=postgresql://username:password@hostname:port/database?sslmode=require
       - DEST_DB_URL=postgres://postgres:postgres@db:5432/explorer
-      - PORT=${API_PORT}
+      - PORT=${PORT}
     restart: always
 
 volumes:


### PR DESCRIPTION
# Update API service configuration for consistent env vars and port mapping

## Description

This PR updates the `docker-compose.yml` file to improve consistency and support for external database connections.

### Changes

- Standardized API service port mapping to use `${PORT}:${PORT}`
- Added `SOURCE_DB_URL` environment variable to enable external source database connectivity
- Ensured `DEST_DB_URL` points to the internal `db` service (`postgres://postgres:postgres@db:5432/explorer`)
- Replaced `${po}` and `${API_PORT}` with a consistent `${PORT}` environment variable

### Why

These changes improve clarity and flexibility in environment variable usage, making the configuration easier to manage across different environments.
