### PR TITLE
Add IBC Client Query Support with Channel and State Information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ futures-util = "0.3"
 async-stream = "0.3"
 tokio-stream = { version = "0.1.17", features = ["sync"] }
 regex = "1.11.1"
+hyper = { version = "0.14", features = ["http1", "http2", "client"] }
+hyper-rustls = { version = "0.23", features = ["http2"] }
+bytes = "1.0"
+http = "0.2"
+tonic = "0.9"
 
 [lib]
 path = "src/lib.rs"

--- a/src/grpc/client.rs
+++ b/src/grpc/client.rs
@@ -44,7 +44,6 @@ pub struct Any {
     pub value: Vec<u8>,
 }
 
-// For querying client connections
 #[derive(Clone, PartialEq, Eq, Message)]
 pub struct QueryClientConnectionsRequest {
     #[prost(string, tag = "1")]

--- a/src/grpc/client.rs
+++ b/src/grpc/client.rs
@@ -1,0 +1,399 @@
+use anyhow::Result;
+use bytes::{BufMut, BytesMut};
+use hyper::client::HttpConnector;
+use hyper::{Body, Client, Request, StatusCode};
+use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
+use prost::Message;
+use std::convert::TryFrom;
+use tracing::{error, info};
+
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct QueryClientStatesRequest {}
+
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct QueryClientStatesResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub client_states: Vec<IdentifiedClientState>,
+}
+
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct IdentifiedClientState {
+    #[prost(string, tag = "1")]
+    pub client_id: String,
+    #[prost(message, optional, tag = "2")]
+    pub client_state: Option<Any>,
+}
+
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct QueryClientStatusRequest {
+    #[prost(string, tag = "1")]
+    pub client_id: String,
+}
+
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct QueryClientStatusResponse {
+    #[prost(string, tag = "1")]
+    pub status: String,
+}
+
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct Any {
+    #[prost(string, tag = "1")]
+    pub type_url: String,
+    #[prost(bytes, tag = "2")]
+    pub value: Vec<u8>,
+}
+
+// For querying client connections
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct QueryClientConnectionsRequest {
+    #[prost(string, tag = "1")]
+    pub client_id: String,
+}
+
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct QueryClientConnectionsResponse {
+    #[prost(string, repeated, tag = "1")]
+    pub connection_paths: Vec<String>,
+    #[prost(bytes, tag = "2")]
+    pub proof: Vec<u8>,
+    #[prost(message, optional, tag = "3")]
+    pub proof_height: Option<Height>,
+}
+
+// For querying connection channels
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct QueryConnectionChannelsRequest {
+    #[prost(string, tag = "1")]
+    pub connection: String,
+}
+
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct QueryConnectionChannelsResponse {
+    #[prost(message, repeated, tag = "1")]
+    pub channels: Vec<IdentifiedChannel>,
+    #[prost(message, optional, tag = "2")]
+    pub height: Option<Height>,
+}
+
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct IdentifiedChannel {
+    #[prost(int32, tag = "1")]
+    pub state: i32,
+    #[prost(int32, tag = "2")]
+    pub ordering: i32,
+    #[prost(message, optional, tag = "3")]
+    pub counterparty: Option<Counterparty>,
+    #[prost(string, repeated, tag = "4")]
+    pub connection_hops: Vec<String>,
+    #[prost(string, tag = "5")]
+    pub version: String,
+    #[prost(string, tag = "6")]
+    pub port_id: String,
+    #[prost(string, tag = "7")]
+    pub channel_id: String,
+}
+
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct Counterparty {
+    #[prost(string, tag = "1")]
+    pub port_id: String,
+    #[prost(string, tag = "2")]
+    pub channel_id: String,
+}
+
+#[derive(Clone, PartialEq, Eq, Message)]
+pub struct Height {
+    #[prost(uint64, tag = "1")]
+    pub revision_number: u64,
+    #[prost(uint64, tag = "2")]
+    pub revision_height: u64,
+}
+
+// Enum definitions for channel state and ordering
+// These are only used in the code, not directly in protocol buffer messages
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+#[repr(i32)]
+pub enum State {
+    #[default]
+    Uninitialized = 0,
+    Init = 1,
+    TryOpen = 2,
+    Open = 3,
+    Closed = 4,
+}
+
+impl TryFrom<i32> for State {
+    type Error = anyhow::Error;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Uninitialized),
+            1 => Ok(Self::Init),
+            2 => Ok(Self::TryOpen),
+            3 => Ok(Self::Open),
+            4 => Ok(Self::Closed),
+            _ => Err(anyhow::anyhow!("Invalid State value: {}", value)),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+#[repr(i32)]
+pub enum Order {
+    #[default]
+    None = 0,
+    Unordered = 1,
+    Ordered = 2,
+}
+
+impl TryFrom<i32> for Order {
+    type Error = anyhow::Error;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::None),
+            1 => Ok(Self::Unordered),
+            2 => Ok(Self::Ordered),
+            _ => Err(anyhow::anyhow!("Invalid Order value: {}", value)),
+        }
+    }
+}
+
+pub const CLIENT_STATUS_ACTIVE: &str = "Active";
+pub const CLIENT_STATUS_FROZEN: &str = "Frozen";
+pub const CLIENT_STATUS_EXPIRED: &str = "Expired";
+pub const CLIENT_STATUS_UNKNOWN: &str = "Unknown";
+
+#[allow(clippy::module_name_repetitions)]
+pub struct GrpcClient {
+    client: Client<HttpsConnector<HttpConnector>>,
+    base_url: String,
+}
+
+impl GrpcClient {
+    #[must_use]
+    pub fn new(host: &str, port: u16) -> Self {
+        let https = HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .https_only()
+            .enable_http1()
+            .enable_http2()
+            .build();
+
+        let client = Client::builder().build(https);
+        let base_url = format!("https://{host}:{port}");
+
+        Self { client, base_url }
+    }
+
+    /// # Errors
+    /// Returns an error if the request fails
+    pub async fn unary<Req, Resp>(&self, path: &str, request: Req) -> Result<Resp>
+    where
+        Req: Message,
+        Resp: Message + Default,
+    {
+        let req_bytes = request.encode_to_vec();
+
+        let mut frame = BytesMut::with_capacity(req_bytes.len() + 5);
+        frame.put_u8(0);
+        #[allow(clippy::cast_possible_truncation)]
+        frame.put_u32(req_bytes.len() as u32);
+        frame.put_slice(&req_bytes);
+
+        let uri = format!("{}{}", self.base_url, path);
+        let req = Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", "application/grpc")
+            .header("te", "trailers")
+            .body(Body::from(frame.freeze()))?;
+
+        let resp = self.client.request(req).await?;
+
+        if resp.status() != StatusCode::OK {
+            return Err(anyhow::anyhow!("HTTP error: {}", resp.status()));
+        }
+
+        let body = hyper::body::to_bytes(resp.into_body()).await?;
+
+        if body.len() < 5 {
+            return Err(anyhow::anyhow!("Response too short"));
+        }
+
+        let compression = body[0];
+        if compression != 0 {
+            return Err(anyhow::anyhow!("Compressed responses not supported"));
+        }
+
+        let length = ((body[1] as usize) << 24)
+            | ((body[2] as usize) << 16)
+            | ((body[3] as usize) << 8)
+            | (body[4] as usize);
+
+        if body.len() < 5 + length {
+            return Err(anyhow::anyhow!("Response truncated"));
+        }
+
+        let mut resp = Resp::default();
+        resp.merge(&body[5..5 + length])?;
+
+        Ok(resp)
+    }
+}
+
+/// # Errors
+/// Returns an error if the gRPC call fails
+pub async fn query_all_client_ids(client: &GrpcClient) -> Result<Vec<String>> {
+    let request = QueryClientStatesRequest {};
+
+    let response: QueryClientStatesResponse = client
+        .unary("/ibc.core.client.v1.Query/ClientStates", request)
+        .await?;
+
+    let client_ids = response
+        .client_states
+        .into_iter()
+        .map(|state| state.client_id)
+        .collect();
+
+    Ok(client_ids)
+}
+
+/// # Errors
+/// Returns an error if the gRPC call fails
+pub async fn query_client_status(client: &GrpcClient, client_id: &str) -> Result<String> {
+    let request = QueryClientStatusRequest {
+        client_id: client_id.to_string(),
+    };
+
+    let response: QueryClientStatusResponse = client
+        .unary("/ibc.core.client.v1.Query/ClientStatus", request)
+        .await?;
+
+    Ok(response.status)
+}
+
+/// Query all clients and their statuses
+///
+/// # Errors
+/// Returns an error if the gRPC calls fail
+pub async fn query_all_clients(client: &GrpcClient) -> Result<Vec<(String, String)>> {
+    let client_ids = query_all_client_ids(client).await?;
+
+    if client_ids.is_empty() {
+        info!("No IBC clients found");
+        return Ok(Vec::new());
+    }
+
+    let mut results = Vec::with_capacity(client_ids.len());
+
+    for client_id in &client_ids {
+        match query_client_status(client, client_id).await {
+            Ok(status) => {
+                results.push((client_id.clone(), status));
+            }
+            Err(e) => {
+                error!("Error querying status for client {}: {}", client_id, e);
+                results.push((client_id.clone(), format!("Error: {e}")));
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+/// # Errors
+/// Returns an error if the gRPC call fails
+pub async fn query_client_connections(client: &GrpcClient, client_id: &str) -> Result<Vec<String>> {
+    let request = QueryClientConnectionsRequest {
+        client_id: client_id.to_string(),
+    };
+
+    let response: QueryClientConnectionsResponse = client
+        .unary("/ibc.core.connection.v1.Query/ClientConnections", request)
+        .await?;
+
+    Ok(response.connection_paths)
+}
+
+/// # Errors
+/// Returns an error if the gRPC call fails
+/// Returns a vector of tuples containing (`port_id`, `channel_id`, `counterparty_channel_id`)
+/// Only returns channels with STATE_OPEN status
+pub async fn query_connection_channels(client: &GrpcClient, connection: &str) -> Result<Vec<(String, String, String)>> {
+    let request = QueryConnectionChannelsRequest {
+        connection: connection.to_string(),
+    };
+
+    let response: QueryConnectionChannelsResponse = client
+        .unary("/ibc.core.channel.v1.Query/ConnectionChannels", request)
+        .await?;
+
+    // Filter channels to only include those with STATE_OPEN status (state value 3)
+    let channels = response
+        .channels
+        .into_iter()
+        .filter(|channel| {
+            match State::try_from(channel.state) {
+                Ok(State::Open) => true,
+                _ => {
+                    info!("Skipping channel {} with non-open state {}", channel.channel_id, channel.state);
+                    false
+                }
+            }
+        })
+        .map(|channel| {
+            let counterparty_channel_id = channel
+                .counterparty
+                .as_ref()
+                .map_or_else(|| "unknown".to_string(), |cp| cp.channel_id.clone());
+
+            (channel.port_id, channel.channel_id, counterparty_channel_id)
+        })
+        .collect();
+
+    Ok(channels)
+}
+
+/// # Errors
+/// Returns an error if the gRPC calls fail
+pub async fn query_all_client_channels(client: &GrpcClient) -> Result<Vec<(String, Vec<(String, String, String)>)>> {
+    let client_ids = query_all_client_ids(client).await?;
+
+    if client_ids.is_empty() {
+        info!("No IBC clients found");
+        return Ok(Vec::new());
+    }
+
+    let mut results = Vec::with_capacity(client_ids.len());
+
+    for client_id in &client_ids {
+        let mut client_channels = Vec::new();
+
+        match query_client_connections(client, client_id).await {
+            Ok(connections) => {
+                for connection in connections {
+                    match query_connection_channels(client, &connection).await {
+                        Ok(channels) => {
+                            for channel_info in channels {
+                                client_channels.push(channel_info);
+                            }
+                        }
+                        Err(e) => {
+                            error!("Error querying channels for connection {}: {}", connection, e);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Error querying connections for client {}: {}", client_id, e);
+            }
+        }
+
+        results.push((client_id.clone(), client_channels));
+    }
+
+    Ok(results)
+}

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -1,0 +1,10 @@
+mod client;
+mod scheduler;
+
+#[allow(clippy::module_name_repetitions)]
+pub use client::GrpcClient;
+pub use client::{
+    query_all_client_channels, query_all_clients, query_client_connections, query_client_status,
+    query_connection_channels,
+};
+pub use scheduler::start_ibc_status_scheduler;

--- a/src/grpc/scheduler.rs
+++ b/src/grpc/scheduler.rs
@@ -6,7 +6,6 @@ use super::client::{
     CLIENT_STATUS_ACTIVE, CLIENT_STATUS_EXPIRED, CLIENT_STATUS_FROZEN, CLIENT_STATUS_UNKNOWN
 };
 
-// Breaking down the function to reduce cognitive complexity
 async fn check_client_statuses(client: &GrpcClient) {
     match query_all_clients(client).await {
         Ok(statuses) => {
@@ -74,10 +73,8 @@ async fn check_ibc_clients() {
     info!("Running scheduled IBC client status check");
     let client = GrpcClient::new("grpc.penumbra.silentvalidator.com", 443);
 
-    // Check client statuses
     check_client_statuses(&client).await;
 
-    // Check client channels
     check_client_channels(&client).await;
 }
 

--- a/src/grpc/scheduler.rs
+++ b/src/grpc/scheduler.rs
@@ -1,0 +1,95 @@
+use std::time::Duration;
+use tokio::time;
+use tracing::{error, info};
+use super::client::{
+    query_all_clients, query_all_client_channels, GrpcClient,
+    CLIENT_STATUS_ACTIVE, CLIENT_STATUS_EXPIRED, CLIENT_STATUS_FROZEN, CLIENT_STATUS_UNKNOWN
+};
+
+// Breaking down the function to reduce cognitive complexity
+async fn check_client_statuses(client: &GrpcClient) {
+    match query_all_clients(client).await {
+        Ok(statuses) => {
+            info!("Retrieved {} IBC client statuses", statuses.len());
+            let active_count = statuses
+                .iter()
+                .filter(|(_, status)| status == CLIENT_STATUS_ACTIVE)
+                .count();
+            let expired_count = statuses
+                .iter()
+                .filter(|(_, status)| status == CLIENT_STATUS_EXPIRED)
+                .count();
+            let frozen_count = statuses
+                .iter()
+                .filter(|(_, status)| status == CLIENT_STATUS_FROZEN)
+                .count();
+            let unknown_count = statuses
+                .iter()
+                .filter(|(_, status)| status == CLIENT_STATUS_UNKNOWN)
+                .count();
+
+            info!(
+                "IBC clients: Total: {}, Active: {}, Expired: {}, Frozen: {}, Unknown: {}",
+                statuses.len(), active_count, expired_count, frozen_count, unknown_count
+            );
+
+            info!("=== IBC Client Status Summary ===");
+            for (client_id, status) in &statuses {
+                info!("Client: {}, Status: {}", client_id, status);
+            }
+            info!("================================");
+        }
+        Err(e) => {
+            error!("Failed to query IBC clients: {}", e);
+        }
+    }
+}
+
+async fn check_client_channels(client: &GrpcClient) {
+    match query_all_client_channels(client).await {
+        Ok(client_channels) => {
+            info!("=== IBC Client Open Channels Summary ===");
+            for (client_id, channels) in &client_channels {
+                if channels.is_empty() {
+                    info!("Client: {} - No open channels found", client_id);
+                } else {
+                    info!("Client: {} - Found {} open channels:", client_id, channels.len());
+                    for (port_id, channel_id, counterparty_channel_id) in channels {
+                        info!(
+                            "    Port: {}, Channel: {}, Counterparty Channel: {}",
+                            port_id, channel_id, counterparty_channel_id
+                        );
+                    }
+                }
+            }
+            info!("=====================================");
+        }
+        Err(e) => {
+            error!("Failed to query IBC client channels: {}", e);
+        }
+    }
+}
+
+async fn check_ibc_clients() {
+    info!("Running scheduled IBC client status check");
+    let client = GrpcClient::new("grpc.penumbra.silentvalidator.com", 443);
+
+    // Check client statuses
+    check_client_statuses(&client).await;
+
+    // Check client channels
+    check_client_channels(&client).await;
+}
+
+#[allow(clippy::module_name_repetitions)]
+pub fn start_ibc_status_scheduler() {
+    tokio::spawn(async {
+        check_ibc_clients().await;
+        let mut interval = time::interval(Duration::from_secs(3600));
+        loop {
+            interval.tick().await;
+            check_ibc_clients().await;
+        }
+    });
+    info!("Started IBC client status scheduler (running hourly)");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod app_views;
 pub mod db_migrations;
+pub mod grpc;
 pub mod options;
 pub mod parsing;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,7 @@ async fn main() -> Result<()> {
     tracing::info!("  Polling Interval (ms): {}", opts.polling_interval_ms);
 
     penumbra_explorer::db_migrations::run_migrations(&opts.dest_db_url)?;
+    penumbra_explorer::grpc::start_ibc_status_scheduler();
 
     let explorer = Explorer::new(opts);
     explorer.run().await?;


### PR DESCRIPTION
# Add IBC Client Query Support with Channel and State Information

## Description

This PR adds support for querying IBC client information via gRPC. It enables fetching client states, connections, channel IDs, and counterparty channel IDs from the Penumbra node. The implementation provides a complete client-side solution to monitor IBC connections, focusing specifically on open channels.

## Background

This PR was inspired by a discussion with David (@jumpiix), who highlighted the need for IBC client information in the explorer. After meeting with David and talking about the issues, I realized I could help since I had recently set up a Penumbra node and understood how this data could be fetched over gRPC. With this knowledge from my node setup experience, I offered to implement the functionality, resulting in this PR with all the necessary client-side code to fetch and process IBC information, including client states, connections, and channel details with their counterparties.

## Implementation Details

Three new files have been added to the `src/grpc` directory:

1. `client.rs` - Handles all the gRPC communication:
   - Message structures for the IBC queries
   - Core client functionality for talking to the node
   - Query functions for various IBC components
   - Error handling and type conversions
   - Logic to get counterparty channel info
   - Filtering to only show STATE_OPEN channels

2. `scheduler.rs` - Sets up an hourly task that:
   - Retrieves all IBC client information
   - Shows which clients are Active/Frozen/Expired
   - Maps out connection information
   - Displays channel and counterparty relationships
   - Logs everything with appropriate levels

3. `mod.rs` - Exports the necessary functions and types

The code follows good Rust practices with proper error handling, documentation, and is fully Clippy-compliant. All code has been thoroughly checked with Clippy and addresses all warnings to ensure high code quality and adherence to Rust's best practices.

## Example Output

When the scheduler runs, it produces this kind of output:

```
[INFO] Running scheduled IBC client status check
[INFO] Retrieved 3 IBC client statuses
[INFO] IBC clients: Total: 3, Active: 2, Expired: 0, Frozen: 1, Unknown: 0
[INFO] === IBC Client Status Summary ===
[INFO] Client: 07-tendermint-0, Status: Active
[INFO] Client: 07-tendermint-1, Status: Active
[INFO] Client: 07-tendermint-2, Status: Frozen
[INFO] ================================
[INFO] === IBC Client Open Channels Summary ===
[INFO] Client: 07-tendermint-0 - Found 1 open channels:
[INFO]     Port: transfer, Channel: channel-6, Counterparty Channel: channel-4886
[INFO] Client: 07-tendermint-1 - Found 2 open channels:
[INFO]     Port: transfer, Channel: channel-3, Counterparty Channel: channel-1242
[INFO]     Port: icacontroller, Channel: channel-4, Counterparty Channel: channel-1243
[INFO] Client: 07-tendermint-2 - No open channels found
[INFO] =====================================
```

## Testing

The implementation has been tested against the live Penumbra node at `grpc.penumbra.silentvalidator.com:443`. It correctly retrieves all IBC client data, including channel and counterparty details. The code specifically filters for STATE_OPEN channels, so only active channels appear in the output.

Here's what a channel response looks like:

```json
{
  "channels": [
    {
      "state": "STATE_OPEN",
      "ordering": "ORDER_UNORDERED",
      "counterparty": {
        "portId": "transfer",
        "channelId": "channel-4886"
      },
      "connectionHops": [
        "connection-7"
      ],
      "version": "ics20-1",
      "portId": "transfer",
      "channelId": "channel-6"
    }
  ],
  "height": {
    "revisionNumber": "1",
    "revisionHeight": "4784447"
  }
}
```

## Next Steps

The next steps are:
- Store the IBC data in the database
- Create GraphQL resolvers to expose this information through the API