### PR TITLE
  v1.4.1 - Validator Subscription Fix

### DIFF
--- a/src/app_views/explorer.rs
+++ b/src/app_views/explorer.rs
@@ -273,7 +273,7 @@ impl Explorer {
         &self,
         dbtx: &mut PgTransaction<'_>,
         height: u64,
-        timestamp: DateTime<Utc>,
+        _timestamp: DateTime<Utc>,
         _ctx: &EventBatchContext,
     ) -> Result<(), anyhow::Error> {
         let block_exists: i64 = match sqlx::query_scalar(
@@ -357,25 +357,16 @@ impl Explorer {
             return Ok(());
         }
 
+        // Don't record any validator blocks here
+        // Let the validator event processing handle everything:
+        // 1. First: MissedBlock events record validators with signed=false
+        // 2. Then: Record remaining ACTIVE validators with signed=true
+
         tracing::debug!(
-            "Recording signed blocks for {} active validators at height {}",
+            "Found {} active validators at height {} - validator event processing will handle block recording",
             active_validators.len(),
             height
         );
-
-        let validator_records: Vec<(String, i64, DateTime<Utc>, bool)> = active_validators
-            .iter()
-            .map(|identity_key| {
-                (
-                    identity_key.clone(),
-                    i64::try_from(height).unwrap_or(i64::MAX),
-                    timestamp,
-                    true,
-                )
-            })
-            .collect();
-
-        let _ = validator::Validator::record_validator_blocks_bulk(&validator_records, dbtx).await;
 
         Ok(())
     }

--- a/src/app_views/utils/validator.rs
+++ b/src/app_views/utils/validator.rs
@@ -827,6 +827,92 @@ impl Validator {
         }
     }
 
+    /// Record ACTIVE validators as signed=true (except those already recorded as missed)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database operation fails.
+    pub async fn record_active_validators_as_signed(
+        dbtx: &mut PgTransaction<'_>,
+        height: u64,
+        timestamp: DateTime<Utc>,
+    ) -> Result<()> {
+        let block_height = i64::try_from(height).unwrap_or(i64::MAX);
+
+        // Get all ACTIVE validators
+        let active_state: Option<String> = sqlx::query_scalar(
+            "SELECT DISTINCT state FROM validators WHERE state LIKE '%ACTIVE%' LIMIT 1",
+        )
+        .fetch_optional(dbtx.as_mut())
+        .await?;
+
+        let Some(state) = active_state else {
+            debug!("No active validator state found, skipping signed block recording");
+            return Ok(());
+        };
+
+        let active_validators: Vec<String> = sqlx::query_scalar(&format!(
+            "SELECT identity_key FROM validators WHERE state = '{state}'"
+        ))
+        .fetch_all(dbtx.as_mut())
+        .await?;
+
+        if active_validators.is_empty() {
+            debug!("No active validators found, skipping signed block recording");
+            return Ok(());
+        }
+
+        // Insert active validators as signed=true, but only if not already recorded
+        // (MissedBlock events would have already inserted them as signed=false)
+        let mut values_clauses = Vec::new();
+        for i in 0..active_validators.len() {
+            let param_base = i * 4;
+            values_clauses.push(format!(
+                "(${}, ${}, ${}, ${})",
+                param_base + 1,
+                param_base + 2,
+                param_base + 3,
+                param_base + 4
+            ));
+        }
+
+        let query = format!(
+            r"
+            INSERT INTO validator_blocks (identity_key, block_height, timestamp, signed)
+            VALUES {}
+            ON CONFLICT (identity_key, block_height) DO NOTHING
+            ",
+            values_clauses.join(", ")
+        );
+
+        let mut sqlx_query = sqlx::query(&query);
+        for identity_key in active_validators {
+            sqlx_query = sqlx_query
+                .bind(identity_key)
+                .bind(block_height)
+                .bind(timestamp)
+                .bind(true); // signed = true
+        }
+
+        match sqlx_query.execute(dbtx.as_mut()).await {
+            Ok(result) => {
+                debug!(
+                    "Recorded {} active validators as signed for block {}",
+                    result.rows_affected(),
+                    height
+                );
+                Ok(())
+            }
+            Err(e) => {
+                error!(
+                    "Failed to record active validators as signed for block {}: {}",
+                    height, e
+                );
+                Ok(()) // Don't fail the entire process for this
+            }
+        }
+    }
+
     /// Calculate total voting power across ACTIVE validators only
     ///
     /// # Errors
@@ -1614,6 +1700,12 @@ impl Validator {
                     identity_key, e
                 );
             }
+        }
+
+        // After processing all events (including MissedBlock events),
+        // record remaining ACTIVE validators as signed=true
+        if let Err(e) = Self::record_active_validators_as_signed(dbtx, height, timestamp).await {
+            error!("Failed to record active validators as signed: {}", e);
         }
 
         Ok(())


### PR DESCRIPTION
  Bug Fix:
  - Fixed duplicate validator block subscription events caused by database trigger firing twice
  - Resolved issue where ON CONFLICT DO UPDATE was triggering notifications for both INSERT and UPDATE operations
  - Restructured validator block recording logic to prevent phantom signed: true events in GraphQL subscriptions

  Technical Changes:
  - Modified record_validator_blocks_for_height to skip automatic validator recording
  - Event processing now handles validator blocks: MissedBlock events → signed: false, remaining active validators → signed: true
  - Changed from ON CONFLICT DO UPDATE to ON CONFLICT DO NOTHING to prevent duplicate triggers
